### PR TITLE
build(docker): docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+doc/build/
+target
+*.sw?
+*.html
+*.1
+*.1.gz
+.vscode/
+tests/functional/output
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.3
+FROM rust:1.70.0-alpine AS build
+
+WORKDIR /usr/local/app
+
+COPY . .
+
+RUN \
+    --mount=type=cache,target=/var/cache/apk \
+    apk add build-base && \
+    cargo build --release
+
+FROM gcr.io/distroless/static-debian11:latest
+
+COPY --from=build /usr/local/app/target/release/stringsext /stringsext
+
+ENTRYPOINT ["/stringsext"]


### PR DESCRIPTION
Here is a `Dockerfile` to build a docker image for `stringsext` if you are interested.

```shell
$ docker run --rm zaventh/stringsext --help
stringsext 2.3.4
Find multi-byte encoded strings in binary data.

USAGE:
    stringsext [FLAGS] [OPTIONS] [--] [FILE]...

FLAGS:
    -d, --debug-option          show how command-line-options are interpreted
    -h, --help                  Prints help information
    -l, --list-encodings        list predefined encoding and filter names for ENC
    -c, --no-metadata           never print byte-counter, encoding or filter
    -r, --same-unicode-block    require chars in finding to be in the same Unicode-block
    -V, --version               print version and exit

OPTIONS:
    -a, --ascii-filter <ascii-filter>
            filter applied after decoding (see `--list-encodings` for AF examples)

    -n, --chars-min <chars-min>                          minimum characters of printed strings
    -s, --counter-offset <counter-offset>                start counting input bytes with NUM
    -e, --encoding <encoding>...                         set (multiple) encodings to search for
    -g, --grep-char <grep-char>                          grep for characters with ASCII-code in output lines
    -p, --output <output>                                print not to stdout but in file
    -q, --output-line-len <output-line-len>              output line length in Unicode-codepoints
    -t, --radix <radix>                                   [possible values: O, X, D]
    -u, --unicode-block-filter <unicode-block-filter>
            filter applied after decoding (see `--list-encodings` for UBF examples)


ARGS:
    <FILE>...    paths to files to scan (or `-` for stdin)
```